### PR TITLE
Update KueStore for use with Rails 4.1

### DIFF
--- a/kue.gemspec
+++ b/kue.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_path  = 'lib'
 
-  s.add_dependency 'activerecord', '~> 4.0.0'
+  s.add_dependency 'activerecord', '>= 4.0.0'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'pry'

--- a/kue.gemspec
+++ b/kue.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_path  = 'lib'
 
-  s.add_dependency 'activerecord', '~> 3.2.3'
+  s.add_dependency 'activerecord', '~> 4.0.0'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'pry'

--- a/lib/kue.rb
+++ b/lib/kue.rb
@@ -21,7 +21,7 @@ module Kue
 
       def []=(key, value)
         raise KueNilKeyError if key.nil?
-        setting = KueStore.find_or_create_by_key(key)
+        setting = KueStore.find_or_create_by(key: key)
         setting.value = value.to_yaml
         setting.save!
       end

--- a/spec/config/database.yml
+++ b/spec/config/database.yml
@@ -1,2 +1,3 @@
-adapter: sqlite3
-database: ":memory:"
+sqlite3:
+  adapter: sqlite3
+  database: ":memory:"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ require File.expand_path('../../lib/kue', __FILE__)
 active_record_configuration = YAML.load_file(File.expand_path('../config/database.yml', __FILE__))
 
 ActiveRecord::Base.configurations = active_record_configuration
-ActiveRecord::Base.establish_connection(active_record_configuration)
+ActiveRecord::Base.establish_connection(:sqlite3)
 
 ActiveRecord::Base.logger = Logger.new(File.join(File.dirname(__FILE__), "debug.log"))
 ActiveRecord::Base.default_timezone = :utc

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,10 +24,8 @@ ActiveRecord::Base.establish_connection(active_record_configuration)
 ActiveRecord::Base.logger = Logger.new(File.join(File.dirname(__FILE__), "debug.log"))
 ActiveRecord::Base.default_timezone = :utc
 
-ActiveRecord::Base.silence do
-  ActiveRecord::Migration.verbose = false
-  load(File.expand_path('../../lib/generators/kue/install/templates/migration.rb', __FILE__))
-end
+ActiveRecord::Migration.verbose = false
+load(File.expand_path('../../lib/generators/kue/install/templates/migration.rb', __FILE__))
 
 #Run the migration
 KueSettingsTableCreateMigration.new.up


### PR DESCRIPTION
All tests pass now with Rails 4.1, though not tested for backwards compatibility—perhaps this could live in a separate branch for Rails 4.1 only?